### PR TITLE
feat: rescale tri

### DIFF
--- a/cenplot/lib/draw/settings.py
+++ b/cenplot/lib/draw/settings.py
@@ -48,7 +48,7 @@ class PlotSettings:
     """
     dim: tuple[float, float] = (20.0, 12.0)
     """
-    The dimensions of each plot.
+    The dimensions of each plot. Format: `(width, height)`
     """
     dpi: int = 600
     """

--- a/cenplot/lib/track/settings.py
+++ b/cenplot/lib/track/settings.py
@@ -97,6 +97,11 @@ class SelfIdentTrackSettings(DefaultTrackSettings):
         * See https://matplotlib.org/stable/users/explain/colors/colors.html
     * ex. `0\t90\tblue`
     """
+    rescale_tri: bool = True
+    """
+    Rescales track proportions so always a right isosceles triangle.
+    * https://byjus.com/maths/isosceles-right-triangle/
+    """
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ exclude = ["docs*", "test*"]
 
 [project]
 name = "cenplot"
-version = "0.1.4"
+version = "0.1.5"
 authors = [
     {name = "Keith Oshima", email = "oshimak@pennmedicine.upenn.edu"},
 ]

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -28,6 +28,8 @@ import tempfile
         ("test/tracks_simple.yaml", "test/chrY/cdrs.bed"),
         # Non-live
         ("test/tracks_mon.yaml", "test/mon/stv.bed.gz"),
+        # Test rescale tri.
+        ("test/tracks_multiple_adj_ht.toml", "test/chrY/cdrs.bed"),
     ],
 )
 def test_cli_draw(track_file: str, ctg_file: str):

--- a/test/tracks_multiple_adj_ht.toml
+++ b/test/tracks_multiple_adj_ht.toml
@@ -1,0 +1,63 @@
+[settings]
+title = "{chrom}"
+format = ["png", "pdf", "svg"]
+transparent = false
+dim = [16.0, 16.0]
+axis_h_pad = 0.05
+dpi = 600
+layout = "constrained"
+
+[[tracks]]
+position = "relative"
+type = "selfident"
+proportion = 0.6
+path = "test/chrY/ident.bed"
+options = { legend = false, hide_x = true, invert = false, legend_asp_ratio = 1.0 }
+
+[[tracks]]
+position = "relative"
+type = "label"
+proportion = 0.005
+path = "test/chrY/cdrs.bed"
+options = { color = "black", legend = false, hide_x = true }
+
+[[tracks]]
+title = "Mean CpG\nmethylation\n(%)"
+position = "relative"
+type = "bar"
+proportion = 0.1
+path = "test/chrY/methyl.bed"
+options = { hide_x = true, ymax = 100.0 }
+
+[[tracks]]
+position = "relative"
+proportion = 0.05
+type = "label"
+path = "test/chrY/sat_annot.bed"
+options = { legend = true, legend_title = "Centromere structure", legend_ncols = 3, hide_x = true }
+
+[[tracks]]
+position = "overlap"
+type = "hor"
+path = "test/chrY/stv.bed"
+options = { legend = true, legend_title = "Centromere structure", sort_order = "descending", hide_x = true, bg_border = true, hor_filter = 1 }
+
+[[tracks]]
+position = "relative"
+proportion = 0.005
+type = "horort"
+path = "test/chrY/stv.bed"
+options = { hide_x = true, scale = 34 }
+
+[[tracks]]
+position = "relative"
+type = "selfident"
+proportion = 0.6
+path = "test/chrY/ident.bed"
+options = { legend = false, hide_x = true, invert = true, legend_asp_ratio = 1.0, rescale_tri = true }
+
+[[tracks]]
+position = "relative"
+type = "position"
+proportion = 0.005
+options = { legend = false, hide_x = false }


### PR DESCRIPTION
* Added option to re-scale the self-identity triangle so always a right isosceles triangle if plot height allows.
* Bumped version to `v0.1.5`
